### PR TITLE
Add microservice input for releasing for microservices

### DIFF
--- a/Source/ICreateRelease.ts
+++ b/Source/ICreateRelease.ts
@@ -17,5 +17,5 @@ export interface ICreateRelease {
      * @param {string} version
      * @returns {Tag[]}
      */
-    create(version: string, body: string): Release
+    create(version: string, body: string, microservice?: string): Release
 }

--- a/Source/Release.ts
+++ b/Source/Release.ts
@@ -5,5 +5,6 @@ export type Release = {
     version: string,
     title: string,
     body: string,
-    isPrerelease: boolean
+    isPrerelease: boolean,
+    microservice?: string
 };

--- a/Source/ReleaseCreator.ts
+++ b/Source/ReleaseCreator.ts
@@ -19,14 +19,21 @@ export class ReleaseCreator implements ICreateRelease {
      * Instantiates an instance of {TagsCreator}.
      * @param {ILogger} _logger
      */
-    constructor(private _logger: ILogger) {}
+    constructor(private _logger: ILogger) { }
 
-    create(version: string, body: string): Release {
+    create(version: string, body: string, microservice: string = ''): Release {
         this._logger.info(`Creating release for version '${version}'`);
         if (!semver.valid(version)) throw new Error(`${version} is not a valid SemVer`);
         version = version.toLowerCase().startsWith('v') ? version : 'v' + version;
         const isPrerelease = semver.parse(version)!.prerelease?.length > 0;
-        const title = `${isPrerelease ? 'Prerelease' : 'Release'} ${version}`;
-        return {version, isPrerelease, title, body};
+        const isForMicroservice = microservice !== '';
+        const title = `${isPrerelease ? 'Prerelease' : 'Release'} ${isForMicroservice ? `${microservice} ` : ''}${version}`;
+        return {
+            version,
+            isPrerelease,
+            title,
+            body,
+            microservice: isForMicroservice ? microservice : undefined
+        };
     }
 }

--- a/Source/VersionReleaser.ts
+++ b/Source/VersionReleaser.ts
@@ -25,7 +25,7 @@ export class VersionReleaser implements IReleaseVersion {
         const releaseResponse = await this._github.repos.createRelease({
             owner: this._owner,
             repo: this._repo,
-            tag_name: release.version,
+            tag_name: `${release.microservice !== undefined ? `${release.microservice}-` : ''}${release.version}`,
             name: release.title,
             body: release.body || '',
             prerelease: release.isPrerelease,

--- a/Source/action.ts
+++ b/Source/action.ts
@@ -16,6 +16,7 @@ export async function run() {
         const token = getInput('token', { required: true });
         const version = getInput('version', { required: true })!;
         const body = getInput('body');
+        const microservice = getInput('microservice');
         const releaseCreator = new ReleaseCreator(logger);
         const { owner, repo } = context.repo;
         const versionReleaser = new VersionReleaser(owner, repo, context.sha, getOctokit(token), logger);

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Github Release'
-description: 'Triggers a GitHub release of a version'
+name: "Github Release"
+description: "Triggers a GitHub release of a version"
 inputs:
   token:
     description: Token to use for Github API
@@ -11,8 +11,12 @@ inputs:
   body:
     description: Release summary
     required: false
-    default: ''
-  
+    default: ""
+  microservice:
+    description: The name of the Microservice that should be released. The name should not contain spaces
+    required: false
+    default: ""
+
 runs:
-  using: 'node12'
-  main: 'release/index.js'
+  using: "node12"
+  main: "release/index.js"


### PR DESCRIPTION
## Summary

Adds the 'microservice' optional input. When given a non-empty string it will create a GitHub release for a particular "microservice" (it'll just affect the release title and the tag) 

### Added

- 'microservice' input for releasing for a microservice when given a non-empty string as input.
