### PR TITLE
Add output for 'upload_url' to allow releasing artefacts on GitHub.

### DIFF
--- a/Source/IReleaseVersion.ts
+++ b/Source/IReleaseVersion.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { Release } from './Release';
+import { ReleaseContext } from './ReleaseContext';
 
 /**
  * Defines a system that that can release a version to GitHub.
@@ -15,7 +16,7 @@ export interface IReleaseVersion {
      * Releases a new version.
      *
      * @param {Release} release
-     * @returns {Promise<void>}
+     * @returns {Promise<ReleaseContext>}
      */
-    release(release: Release): Promise<void>
+    release(release: Release): Promise<ReleaseContext>;
 }

--- a/Source/ReleaseContext.ts
+++ b/Source/ReleaseContext.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * The context of a release.
+ */
+ export type ReleaseContext = {
+    uploadUrl: string,
+};

--- a/Source/VersionReleaser.ts
+++ b/Source/VersionReleaser.ts
@@ -5,6 +5,7 @@ import { ILogger } from '@dolittle/github-actions.shared.logging';
 import { IReleaseVersion } from './IReleaseVersion';
 import { Release } from './Release';
 import { GitHub } from '@actions/github/lib/utils';
+import { ReleaseContext } from './ReleaseContext';
 
 export class VersionReleaser implements IReleaseVersion {
 
@@ -16,7 +17,7 @@ export class VersionReleaser implements IReleaseVersion {
         private readonly _logger: ILogger) {
     }
 
-    async release(release: Release) {
+    async release(release: Release): Promise<ReleaseContext> {
         this._logger.debug(`Creating release with version '${release.version}' and title '${release.title}' on repository 'github.com/${this._owner}/${this._repo}'`);
 
         // GitHub Create Release documentation: https://developer.github.com/v3/repos/releases/#create-a-release
@@ -32,7 +33,11 @@ export class VersionReleaser implements IReleaseVersion {
             target_commitish: this._sha
 
         });
+
         this._logger.debug(`Status: ${releaseResponse.status}`);
 
+        return {
+            uploadUrl: releaseResponse.data.upload_url,
+        };
     }
 }

--- a/Source/action.ts
+++ b/Source/action.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { getInput, setFailed } from '@actions/core';
+import { getInput, setOutput, setFailed } from '@actions/core';
 import { getOctokit, context } from '@actions/github';
 import { Logger } from '@dolittle/github-actions.shared.logging';
 import { getInputAsBoolean } from '@dolittle/github-actions.shared.rudiments';
+import { ReleaseContext } from './ReleaseContext';
 import { ReleaseCreator } from './ReleaseCreator';
 import { VersionReleaser } from './VersionReleaser';
 
@@ -24,10 +25,24 @@ export async function run() {
 
         logger.info(`Release prepared for ${release.version} - ${release.title}`);
 
-        await versionReleaser.release(release);
+        const releaseContext = await versionReleaser.release(release);
+        logger.info(`Created release ${release.version} - ${release.title}`);
+        outputContext(releaseContext);
     } catch (error) {
         fail(error);
     }
+}
+
+function output(
+    uploadUrl: string) {
+    logger.info('Outputting: ');
+    logger.info(`'upload_url': ${uploadUrl}`);
+
+    setOutput('upload_url', uploadUrl);
+}
+function outputContext(context: ReleaseContext) {
+    output(
+        context.uploadUrl);
 }
 
 function fail(error: Error) {

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
     description: The name of the Microservice that should be released. The name should not contain spaces
     required: false
     default: ""
+outputs:
+  upload_url:
+    description: The URL for uploading assets to the release
 
 runs:
   using: "node12"


### PR DESCRIPTION
## Summary

Adds an output called 'upload_url' inspired by https://github.com/actions/create-release to allow us to use https://github.com/actions/upload-release-asset to upload artefacts to the release.

### Added

- An output called 'upload_url' to use to upload assets to the release later in workflows.